### PR TITLE
Add symlink fonts to Dockerfile(Fixes #217)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,9 @@ RUN gem install bundler:2.0.2 && \
 # Install the application
 COPY . /app
 
+# Create symlink fonts
+RUN ln -s /app/vendor/assets/fonts /usr/share/fonts
+
 # Generate version file if available
 RUN if [ -d .git ]; then git describe --always > VERSION; fi
 


### PR DESCRIPTION
- Fixes #217 - missing Unicode font in docker image(Dockerfile)