### PR TITLE
Field: clean code to prevent skip logic errors

### DIFF
--- a/app/models/field.rb
+++ b/app/models/field.rb
@@ -38,6 +38,7 @@ class Field < ApplicationRecord
   attr_accessor :skip_validation
 
   FIELD_TYPES = %w[Fields::TextField Fields::NoteField Fields::IntegerField Fields::DateField Fields::DateTimeField Fields::SelectOneField Fields::SelectMultipleField Fields::ImageField Fields::FileField Fields::LocationField Fields::MappingField].freeze
+  SPECIAL_CHARATER_REG_EXP="[^0-9A-Za-z\_]"
 
   # Association
   belongs_to :section
@@ -52,7 +53,7 @@ class Field < ApplicationRecord
   validates :field_type, presence: true, inclusion: { in: FIELD_TYPES }
   validates :mapping_field_id, presence: true, if: -> { field_type == "Fields::MappingField" && !skip_validation }
 
-  before_validation :set_field_code, if: -> { name.present? }
+  before_validation :set_code, if: -> { name.present? }
   before_validation :set_mapping_field_type
   before_validation :set_milestone
   before_create :set_display_order
@@ -128,7 +129,7 @@ class Field < ApplicationRecord
   end
 
   def format_name
-    name.downcase.split(" ").join("_")
+    name.downcase.split(" ").join("_").gsub(/#{SPECIAL_CHARATER_REG_EXP}/, "")
   end
 
   def relevant_format_code
@@ -147,7 +148,7 @@ class Field < ApplicationRecord
   end
 
   private
-    def set_field_code
+    def set_code
       self.code ||= format_name
     end
 

--- a/lib/tasks/field.rake
+++ b/lib/tasks/field.rake
@@ -30,4 +30,13 @@ namespace :field do
   task migrate_skip_logic_fields_not_to_required: :environment do
     Field.where(required: true).where.not(relevant: nil).update_all(required: false)
   end
+
+  desc "migrate field codes that have special character" do
+  task migrate_field_code_having_special_character: :environment do
+    fields = Field.where("code ~* ?", Field::SPECIAL_CHARATER_REG_EXP)
+    fields.includes(:field_values).each do |field|
+      field.update_column(:code, field.code.gsub(/#{Field::SPECIAL_CHARATER_REG_EXP}/, ""))
+      field.field_values.update_all(field_code: field.code)
+    end
+  end
 end

--- a/spec/models/field_spec.rb
+++ b/spec/models/field_spec.rb
@@ -29,4 +29,14 @@ RSpec.describe Field, type: :model do
       it { is_expected.not_to validate_presence_of(:mapping_field_id) }
     end
   end
+
+  describe ".before_validation, set_code" do
+    let(:field) { build(:field, name: "Any possible to having new case?", code: nil) }
+
+    it "sets code with clearing special character" do
+      field.valid?
+
+      expect(field.code).to eq("any_possible_to_having_new_case")
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,6 +47,7 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
+  config.filter_run_when_matching :focus
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin


### PR DESCRIPTION
When deploy, please run this task
$rake field:migrate_field_code_having_special_character